### PR TITLE
fix #25

### DIFF
--- a/src/selectfield/selectfield.js
+++ b/src/selectfield/selectfield.js
@@ -168,8 +168,13 @@
         this.select_.addEventListener('blur', this.boundBlurHandler);
         this.select_.addEventListener('reset', this.boundResetHandler);
 
+        var invalid = this.element_.classList
+          .contains(this.CssClasses_.IS_INVALID);
         this.updateClasses_();
         this.element_.classList.add(this.CssClasses_.IS_UPGRADED);
+        if (invalid) {
+          this.element_.classList.add(this.CssClasses_.IS_INVALID);
+        }
       }
     }
   };


### PR DESCRIPTION
When `is-invalid` class is statically added to the select field element, the error is displayed.
