### PR TITLE
Refactored selectfield.scss into _variables and _selectfield.scss

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Then include in your html:
 <script src="./bower_components/mdl-selectfield/dist/mdl-selectfield.min.js"></script>
 ````
 
+Alternatively you may import the following published scss files in your build pipeline for extending the variables.
+ 
+````
+dist/scss/selectfield/_variables.scss
+                      _selectfield.scss
+````
+
+OR just 
+````
+dist/scss/selectfield/mdl-selectfield.scss
+````
+
 ## Basic use
 To use any MDL component, you must include the minified CSS and JavaScript files using standard relative-path references in the `<head>` section of the page, as described in the MDL Introduction.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,6 @@
   'use strict';
 
   var gulp = require('gulp'),
-      concat = require('gulp-concat'),
       rename = require('gulp-rename'),
       sass = require('gulp-sass'),
       sourcemaps = require('gulp-sourcemaps'),

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@
       sourcemaps = require('gulp-sourcemaps'),
       sassFiles = [
         './src/global.scss',
-        './src/**/*.scss'
+        './src/selectfield/mdl-selectfield.scss'
       ],
       uglify = require('gulp-uglifyjs'),
       jsFiles = ['src/**/*.js'];
@@ -16,16 +16,10 @@
   gulp.task('sass-compress', function() {
     gulp
       .src(sassFiles)
-      .pipe(concat('file.scss'))
       .pipe(sourcemaps.init())
-      .pipe(sass({
+      .pipe(sass({includePaths: ['./src'],
         outputStyle: 'compressed'
       }).on('error', sass.logError))
-      .pipe(rename(function(path) {
-        path.dirname = '';
-        path.basename = 'mdl-selectfield';
-        path.extname = '.min.css';
-      }))
       .pipe(sourcemaps.write('./'))
       .pipe(gulp.dest('./dist'));
   });
@@ -33,7 +27,6 @@
   gulp.task('sass', function () {
     gulp
       .src(sassFiles)
-      .pipe(concat('mdl-selectfield.scss'))
       .pipe(sass({
         sourceComments: false
       }).on('error', sass.logError))
@@ -60,12 +53,18 @@
       .pipe(gulp.dest('./dist'));
   });
 
+
   gulp.task('watch', function () {
     gulp.watch(sassFiles, ['sass', 'sass-compress']);
     gulp.watch(jsFiles, ['js', 'js-compress']);
   });
 
-  gulp.task('build', ['sass', 'sass-compress', 'js', 'js-compress']);
+  gulp.task('copy-scss-src', function () {
+    gulp.src('src/**/*scss')
+        .pipe(gulp.dest('dist/scss'));
+  });
+
+  gulp.task('build', ['sass', 'sass-compress', 'js', 'js-compress', 'copy-scss-src']);
 
   // The default task (called when you run `gulp` from cli)
   gulp.task('default', ['watch']);

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.0.4",
+    "gulp-sass": "^3.1.0",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglifyjs": "^0.6.2"
   },

--- a/src/selectfield/_selectfield.scss
+++ b/src/selectfield/_selectfield.scss
@@ -1,16 +1,6 @@
-$selectfield-font-size: 16px !default;
-$selectfield-padding: 4px !default;
-$selectfield-vertical-spacing: 20px !default;
-
-$selectfield-floating-label-fontsize: 12px !default;
-
-$selectfield-background-color: transparent !default;
-$selectfield-label-color: unquote("rgba(#{$color-black}, 0.26)") !default;
-$selectfield-bottom-border-color: unquote("rgba(#{$color-black}, 0.12)") !default;
-$selectfield-highlight-color: unquote("rgb(#{$color-primary})") !default;
-$selectfield-disabled-color: $selectfield-bottom-border-color !default;
-$selectfield-disabled-text-color: $selectfield-label-color !default;
-$selectfield-error-color: unquote("rgb(222, 50, 38)") !default;
+@import "../../bower_components/material-design-lite/src/variables";
+@import "../../bower_components/material-design-lite/src/mixins";
+@import 'variables';
 
 // The container for the whole component.
 .mdl-selectfield {

--- a/src/selectfield/_variables.scss
+++ b/src/selectfield/_variables.scss
@@ -1,0 +1,13 @@
+$selectfield-font-size: 16px !default;
+$selectfield-padding: 4px !default;
+$selectfield-vertical-spacing: 20px !default;
+
+$selectfield-floating-label-fontsize: 12px !default;
+
+$selectfield-background-color: transparent !default;
+$selectfield-label-color: unquote("rgba(#{$color-black}, 0.26)") !default;
+$selectfield-bottom-border-color: unquote("rgba(#{$color-black}, 0.12)") !default;
+$selectfield-highlight-color: unquote("rgb(#{$color-primary})") !default;
+$selectfield-disabled-color: $selectfield-bottom-border-color !default;
+$selectfield-disabled-text-color: $selectfield-label-color !default;
+$selectfield-error-color: unquote("rgb(222, 50, 38)") !default;

--- a/src/selectfield/mdl-selectfield.scss
+++ b/src/selectfield/mdl-selectfield.scss
@@ -1,0 +1,1 @@
+@import 'selectfield';


### PR DESCRIPTION
Refactored selectfield.scss into _variables and _selectfield.scss.

Gulpfile changes: 
Copying scss files to dist
Other minor `gulpfile.js` simplifications.

By refactoring we can let users of `mdl-selectfield` extend these variables and further customize in their project. For example someone may want to change color  as in  #34.

Other cases are where certain projects may not want to directly include the css into their index.html (e.g. Angular projects). With this change they can bake their scss using these scss. 